### PR TITLE
Update tests for new heartbeat endpoint

### DIFF
--- a/helper-installer/tests/test_api.py
+++ b/helper-installer/tests/test_api.py
@@ -1,11 +1,14 @@
 import json
-from unittest import mock
+import os
+import queue
 import sys
+import threading
 import types
+from unittest import mock
 
-import requests
 import requests_mock
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import main
 
 
@@ -16,12 +19,30 @@ def test_fetch_user_info():
         assert data["name"] == "tester"
 
 
-def test_fetch_heartbeat():
+def test_heartbeat_loop_post(monkeypatch):
+    class Stopper:
+        def __init__(self):
+            self.called = False
+
+        def is_set(self):
+            return self.called
+
+        def wait(self, timeout):
+            self.called = True
+            return True
+
     with requests_mock.Mocker() as m:
-        m.get("https://api.aichain.io/v1/heartbeat", json={"ok": True})
-        data = main.fetch_heartbeat("key")
-        assert data["ok"] is True
-        assert "latency_ms" in data
+        m.post(main.BASE_URL + main.HEARTBEAT_ENDPOINT, json={"ok": True})
+        monkeypatch.setattr(main, "HEARTBEAT_INTERVAL", 0)
+        monkeypatch.setattr(main, "get_gpu_info", lambda: [])
+        q = queue.Queue()
+        stopper = Stopper()
+        main.heartbeat_loop("key", "wallet", q, stopper)
+        assert m.called
+        req = m.request_history[0]
+        assert req.method == "POST"
+        assert req.json() == {"wallet": "wallet", "gpu_count": 0}
+        assert not q.empty()
 
 
 def test_get_gpu_info():
@@ -35,5 +56,17 @@ def test_get_gpu_info():
     data = main.get_gpu_info()
     assert data[0]["name"] == "GPU"
     assert data[0]["memory_total"] == 1000
+
+
+def test_save_and_load_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    monkeypatch.setattr(main, "CONFIG_PATH", cfg)
+    main.save_config("abc", "wallet1")
+    assert cfg.exists()
+    with open(cfg) as f:
+        data = json.load(f)
+    assert data == {"api_key": "abc", "wallet": "wallet1"}
+    loaded = main.load_config()
+    assert loaded == {"api_key": "abc", "wallet": "wallet1"}
 
 


### PR DESCRIPTION
## Summary
- adjust import path for tests
- test POST `/heartbeat` via `heartbeat_loop`
- verify save and load configuration helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628d57b17c8325a7b0cf96cfad3a4c